### PR TITLE
Update OSCmoothBehavior.cs

### DIFF
--- a/Packages/dev.azmidi.oscmooth/Script/OSCmoothBehavior.cs
+++ b/Packages/dev.azmidi.oscmooth/Script/OSCmoothBehavior.cs
@@ -7,6 +7,7 @@ using VRC.SDK3.Avatars.ScriptableObjects;
 
 namespace OSCmooth
 {
+    [AddComponentMenu("Azmidi/OSCmooth", 0)]
     public class OSCmoothBehavior : MonoBehaviour, IEditorOnly
     {
         [HideInInspector] public OSCmoothSetup setup;


### PR DESCRIPTION
Add friendly name to the behavior script.
This changes the title in the inspector from "OS Cmooth Behavior (Script)" to "OSCmooth".
The script becomes accessible under the submenu "Azmidi" when adding a component to a game object.

For consideration:
If everyone uses their own namespace when adding Shaders and Components for VRChat, with a lot of packages loaded the dropdown menu would get quite large. I suggest for stuff that's mean to work in tandem with the VRC SDK we should use a unified name. Something like "VRChat/OSCmooth".